### PR TITLE
BUILD-2938 no longer use deprecated set-output

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -34,7 +34,7 @@ jobs:
           GOARCH=${GOOSARCH#*/}
           echo "GOOS=$GOOS" >> $GITHUB_ENV
           echo "GOARCH=$GOARCH" >> $GITHUB_ENV
-          echo "::set-output name=filename::${{ inputs.name }}-${GOOS}-${GOARCH}"
+          echo "filename=${{ inputs.name }}-${GOOS}-${GOARCH}" >> "$GITHUB_OUTPUT"
     - name: checkout plugin repo
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
# BUILD-2938 no longer use deprecated set-output

## Changes
* no longer use deprecated set-output